### PR TITLE
Donut & Scatter OnClick Prop Enabled

### DIFF
--- a/src/hooks/useMarkOnClicks.tsx
+++ b/src/hooks/useMarkOnClicks.tsx
@@ -15,6 +15,8 @@ import { getAllMarkElements } from '@utils';
 
 import { Chart } from '../Chart';
 import { Bar } from '../components/Bar';
+import { Donut } from 'rc/components';
+import { Scatter } from '../components/Scatter';
 import { BarElement, ChartChildElement, Datum } from '../types';
 
 type MappedMarkElement = { name: string; element: BarElement };
@@ -26,7 +28,7 @@ export type MarkDetail = {
 
 export default function useMarkOnClicks(children: ChartChildElement[]): MarkDetail[] {
     const markElements = useMemo(
-		() => getAllMarkElements(createElement(Chart, { data: [] }, children), Bar, []) as MappedMarkElement[],
+		() => getAllMarkElements(createElement(Chart, { data: [] }, children), [Bar, Donut, Scatter], []) as MappedMarkElement[],
 		[children]
 	);
 	return useMemo(

--- a/src/hooks/useMarkOnClicks.tsx
+++ b/src/hooks/useMarkOnClicks.tsx
@@ -17,9 +17,9 @@ import { Chart } from '../Chart';
 import { Bar } from '../components/Bar';
 import { Donut } from 'rc/components';
 import { Scatter } from '../components/Scatter';
-import { BarElement, ChartChildElement, Datum } from '../types';
+import { BarElement, ChartChildElement, Datum, DonutElement, ScatterElement } from '../types';
 
-type MappedMarkElement = { name: string; element: BarElement };
+type MappedMarkElement = { name: string; element: BarElement | DonutElement | ScatterElement };
 
 export type MarkDetail = {
 	markName?: string;

--- a/src/specBuilder/donut/donutUtils.ts
+++ b/src/specBuilder/donut/donutUtils.ts
@@ -10,7 +10,7 @@
  * governing permissions and limitations under the License.
  */
 import { DONUT_RADIUS, FILTERED_TABLE, MARK_ID, SELECTED_ITEM } from '@constants';
-import { getColorProductionRule, getCursor, getMarkOpacity, getTooltip } from '@specBuilder/marks/markUtils';
+import { getColorProductionRule, getCursor, getInteractive, getMarkOpacity, getTooltip } from '@specBuilder/marks/markUtils';
 import { getColorValue } from '@specBuilder/specUtils';
 import { ArcMark } from 'vega';
 
@@ -22,6 +22,7 @@ export const getArcMark = (props: DonutSpecProps): ArcMark => {
 		type: 'arc',
 		name,
 		from: { data: FILTERED_TABLE },
+		interactive: getInteractive(children, props),
 		encode: {
 			enter: {
 				fill: getColorProductionRule(color, colorScheme),
@@ -37,7 +38,7 @@ export const getArcMark = (props: DonutSpecProps): ArcMark => {
 				innerRadius: { signal: `${holeRatio} * ${DONUT_RADIUS}` },
 				outerRadius: { signal: DONUT_RADIUS },
 				opacity: getMarkOpacity(props),
-				cursor: getCursor(children),
+				cursor: getCursor(children, props),
 				strokeWidth: [{ test: `${SELECTED_ITEM} === datum.${MARK_ID}`, value: 2 }, { value: 0 }],
 			},
 		},

--- a/src/specBuilder/marks/markUtils.ts
+++ b/src/specBuilder/marks/markUtils.ts
@@ -63,13 +63,16 @@ import {
 	OpacityFacet,
 	ProductionRuleTests,
 	ScaleType,
+	ScatterSpecProps,
 	SymbolSizeFacet,
 } from '../../types';
+
+type MarkElementProps = BarSpecProps | DonutSpecProps | ScatterSpecProps;
 
 /**
  * If a popover or onClick prop exists on the mark, then set the cursor to a pointer.
  */
-export function getCursor(children: MarkChildElement[], props?: BarSpecProps): ScaledValueRef<Cursor> | undefined {
+export function getCursor(children: MarkChildElement[], props?: MarkElementProps): ScaledValueRef<Cursor> | undefined {
 	if ((props?.onClick !== undefined) || hasPopover(children)) {
 		return { value: 'pointer' };
 	}
@@ -79,7 +82,7 @@ export function getCursor(children: MarkChildElement[], props?: BarSpecProps): S
  * If there aren't any tooltips, popovers, or onClick props on the mark, then set interactive to false.
  * This prevents the mark from interfering with other interactive marks.
  */
-export function getInteractive(children: MarkChildElement[], props?: BarSpecProps): boolean {
+export function getInteractive(children: MarkChildElement[], props?: MarkElementProps): boolean {
 	// skip annotations
 	return (props?.onClick !== undefined) || hasInteractiveChildren(children);
 }

--- a/src/specBuilder/scatter/scatterMarkUtils.ts
+++ b/src/specBuilder/scatter/scatterMarkUtils.ts
@@ -13,6 +13,8 @@ import { DEFAULT_OPACITY_RULE, FILTERED_TABLE, HIGHLIGHT_CONTRAST_RATIO, MARK_ID
 import { addTooltipMarkOpacityRules } from '@specBuilder/chartTooltip/chartTooltipUtils';
 import {
 	getColorProductionRule,
+	getCursor,
+	getInteractive,
 	getLineWidthProductionRule,
 	getOpacityProductionRule,
 	getPointsForVoronoi,
@@ -70,6 +72,7 @@ export const getScatterMark = (props: ScatterSpecProps): SymbolMark => {
 		from: {
 			data: FILTERED_TABLE,
 		},
+		interactive: getInteractive(props.children, props),
 		encode: {
 			enter: {
 				/**
@@ -87,6 +90,7 @@ export const getScatterMark = (props: ScatterSpecProps): SymbolMark => {
 				stroke: getColorProductionRule(color, colorScheme, colorScaleType),
 			},
 			update: {
+				cursor: getCursor(props.children, props),
 				opacity: getOpacity(props),
 				x: getXProductionRule(dimensionScaleType, dimension),
 				y: { scale: 'yLinear', field: metric },

--- a/src/stories/components/Donut/Donut.story.tsx
+++ b/src/stories/components/Donut/Donut.story.tsx
@@ -98,23 +98,26 @@ const interactiveChildren = [
 	</ChartPopover>,
 ];
 
-const Basic = bindWithProps(DonutStory);
-Basic.args = {
+const defaultProps: DonutProps = {
 	metric: 'count',
 	color: 'browser',
+	onClick: undefined,
+};
+
+const Basic = bindWithProps(DonutStory);
+Basic.args = {
+	...defaultProps
 };
 
 const WithPopover = bindWithProps(DonutStory);
 WithPopover.args = {
-	metric: 'count',
-	color: 'browser',
+	...defaultProps,
 	children: interactiveChildren,
 };
 
 const WithLegend = bindWithProps(DonutLegendStory);
 WithLegend.args = {
-	metric: 'count',
-	color: 'browser',
+	...defaultProps
 };
 
 const BooleanDonut = bindWithProps(BooleanStory);
@@ -126,10 +129,15 @@ BooleanDonut.args = {
 
 const Supreme = bindWithProps(DonutLegendStory);
 Supreme.args = {
-	metric: 'count',
-	color: 'browser',
+	...defaultProps,
 	holeRatio: 0.8,
 	children: [...interactiveChildren, <DonutSummary label="Visitors" key={0} />],
 };
 
-export { Basic, BooleanDonut, Supreme, WithLegend, WithPopover };
+const OnClick = bindWithProps(DonutStory);
+OnClick.args = {
+	metric: 'count',
+	color: 'browser',
+}
+
+export { Basic, BooleanDonut, Supreme, WithLegend, WithPopover, OnClick };

--- a/src/stories/components/Donut/Donut.test.tsx
+++ b/src/stories/components/Donut/Donut.test.tsx
@@ -9,10 +9,11 @@
  * OF ANY KIND, either express or implied. See the License for the specific language
  * governing permissions and limitations under the License.
  */
-import { findAllMarksByGroupName, findChart, render } from '@test-utils';
+import { clickNthElement, findAllMarksByGroupName, findChart, render } from '@test-utils';
 import { Donut } from 'rc/components/Donut';
 
-import { Basic } from './Donut.story';
+import { Basic, OnClick } from './Donut.story';
+import { basicDonutData } from './data';
 
 describe('Donut', () => {
 	// Donut is not a real React component. This is test just provides test coverage for sonarqube
@@ -28,5 +29,33 @@ describe('Donut', () => {
 		// donut data has 7 segments
 		const bars = await findAllMarksByGroupName(chart, 'donut0');
 		expect(bars.length).toEqual(7);
+	});
+
+	test('should call onClick callback when selecting a donut item', async () => {
+		const onClick = jest.fn();
+		render(<OnClick {...OnClick.args} onClick={onClick} />);
+		const chart = await findChart();
+		const donutItems = await findAllMarksByGroupName(chart, 'donut0');
+
+		await clickNthElement(donutItems, 0);
+		expect(onClick).toHaveBeenCalledWith(expect.objectContaining(basicDonutData[0]));
+
+		await clickNthElement(donutItems, 1);
+		expect(onClick).toHaveBeenCalledWith(expect.objectContaining(basicDonutData[1]));
+
+		await clickNthElement(donutItems, 2);
+		expect(onClick).toHaveBeenCalledWith(expect.objectContaining(basicDonutData[2]));
+
+		await clickNthElement(donutItems, 3);
+		expect(onClick).toHaveBeenCalledWith(expect.objectContaining(basicDonutData[3]));
+
+		await clickNthElement(donutItems, 4);
+		expect(onClick).toHaveBeenCalledWith(expect.objectContaining(basicDonutData[4]));
+
+		await clickNthElement(donutItems, 5);
+		expect(onClick).toHaveBeenCalledWith(expect.objectContaining(basicDonutData[5]));
+
+		await clickNthElement(donutItems, 6);
+		expect(onClick).toHaveBeenCalledWith(expect.objectContaining(basicDonutData[6]));
 	});
 });

--- a/src/stories/components/Scatter/Scatter.story.tsx
+++ b/src/stories/components/Scatter/Scatter.story.tsx
@@ -136,48 +136,48 @@ const dialog = (item: Datum): ReactNode => {
 	);
 };
 
-const Basic = bindWithProps(ScatterStory);
-Basic.args = {
+const defaultProps: ScatterProps = {
 	dimension: 'speedNormal',
 	metric: 'handlingNormal',
+	onClick: undefined,
+}
+
+const Basic = bindWithProps(ScatterStory);
+Basic.args = {
+	...defaultProps
 };
 
 const Color = bindWithProps(ScatterStory);
 Color.args = {
+	...defaultProps,
 	color: 'weightClass',
-	dimension: 'speedNormal',
-	metric: 'handlingNormal',
 };
 
 const ColorScaleType = bindWithProps(ScatterStory);
 ColorScaleType.args = {
+	...defaultProps,
 	color: 'weight',
 	colorScaleType: 'linear',
-	dimension: 'speedNormal',
-	metric: 'handlingNormal',
 };
 
 const LineType = bindWithProps(ScatterStory);
 LineType.args = {
+	...defaultProps,
 	lineType: 'weightClass',
 	lineWidth: { value: 2 },
 	opacity: { value: 0.5 },
-	dimension: 'speedNormal',
-	metric: 'handlingNormal',
 };
 
 const Opacity = bindWithProps(ScatterStory);
 Opacity.args = {
+	...defaultProps,
 	opacity: 'weightClass',
-	dimension: 'speedNormal',
-	metric: 'handlingNormal',
 };
 
 const Popover = bindWithProps(ScatterStory);
 Popover.args = {
+	...defaultProps,
 	color: 'weightClass',
-	dimension: 'speedNormal',
-	metric: 'handlingNormal',
 	children: [
 		<ChartTooltip key="0">{dialog}</ChartTooltip>,
 		<ChartPopover key="1" width="auto">
@@ -188,17 +188,21 @@ Popover.args = {
 
 const Size = bindWithProps(ScatterStory);
 Size.args = {
+	...defaultProps,
 	size: 'weight',
-	dimension: 'speedNormal',
-	metric: 'handlingNormal',
 };
 
 const Tooltip = bindWithProps(ScatterStory);
 Tooltip.args = {
+	...defaultProps,
 	color: 'weightClass',
-	dimension: 'speedNormal',
-	metric: 'handlingNormal',
 	children: <ChartTooltip>{dialog}</ChartTooltip>,
 };
 
-export { Basic, Color, ColorScaleType, LineType, Opacity, Popover, Size, Tooltip };
+const OnClick = bindWithProps(ScatterStory);
+OnClick.args = {
+	dimension: 'speedNormal',
+	metric: 'handlingNormal',
+}
+
+export { Basic, Color, ColorScaleType, LineType, Opacity, Popover, Size, Tooltip, OnClick };

--- a/src/stories/components/Scatter/Scatter.test.tsx
+++ b/src/stories/components/Scatter/Scatter.test.tsx
@@ -25,7 +25,8 @@ import {
 } from '@test-utils';
 import userEvent from '@testing-library/user-event';
 
-import { Basic, Color, ColorScaleType, LineType, Opacity, Popover, Size, Tooltip } from './Scatter.story';
+import { Basic, Color, ColorScaleType, LineType, Opacity, Popover, Size, Tooltip, OnClick } from './Scatter.story';
+import { characterData } from '@stories/data/marioKartData';
 
 const colors = spectrumColors.light;
 
@@ -102,6 +103,60 @@ describe('Scatter', () => {
 		expect(points[0]).toHaveAttribute('fill-opacity', '1');
 		expect(points[6]).toHaveAttribute('fill-opacity', '0.75');
 		expect(points[11]).toHaveAttribute('fill-opacity', '0.5');
+	});
+
+	test('should call onClick callback when selecting a scatter item', async () => {
+		const onClick = jest.fn();
+		render(<OnClick {...OnClick.args} onClick={onClick} />);
+		const chart = await findChart();
+		const scatterItems = await findAllMarksByGroupName(chart, 'scatter0');
+		await clickNthElement(scatterItems, 0);
+		expect(onClick).toHaveBeenCalledWith(expect.objectContaining(characterData[0]));
+
+		await clickNthElement(scatterItems, 1);
+		expect(onClick).toHaveBeenCalledWith(expect.objectContaining(characterData[1]));
+
+		await clickNthElement(scatterItems, 2);
+		expect(onClick).toHaveBeenCalledWith(expect.objectContaining(characterData[2]));
+
+		await clickNthElement(scatterItems, 3);
+		expect(onClick).toHaveBeenCalledWith(expect.objectContaining(characterData[3]));
+
+		await clickNthElement(scatterItems, 4);
+		expect(onClick).toHaveBeenCalledWith(expect.objectContaining(characterData[4]));
+
+		await clickNthElement(scatterItems, 5);
+		expect(onClick).toHaveBeenCalledWith(expect.objectContaining(characterData[5]));
+
+		await clickNthElement(scatterItems, 6);
+		expect(onClick).toHaveBeenCalledWith(expect.objectContaining(characterData[6]));
+
+		await clickNthElement(scatterItems, 7);
+		expect(onClick).toHaveBeenCalledWith(expect.objectContaining(characterData[7]));
+
+		await clickNthElement(scatterItems, 8);
+		expect(onClick).toHaveBeenCalledWith(expect.objectContaining(characterData[8]));
+
+		await clickNthElement(scatterItems, 9);
+		expect(onClick).toHaveBeenCalledWith(expect.objectContaining(characterData[9]));
+
+		await clickNthElement(scatterItems, 10);
+		expect(onClick).toHaveBeenCalledWith(expect.objectContaining(characterData[10]));
+
+		await clickNthElement(scatterItems, 11);
+		expect(onClick).toHaveBeenCalledWith(expect.objectContaining(characterData[11]));
+
+		await clickNthElement(scatterItems, 12);
+		expect(onClick).toHaveBeenCalledWith(expect.objectContaining(characterData[12]));
+
+		await clickNthElement(scatterItems, 13);
+		expect(onClick).toHaveBeenCalledWith(expect.objectContaining(characterData[13]));
+
+		await clickNthElement(scatterItems, 14);
+		expect(onClick).toHaveBeenCalledWith(expect.objectContaining(characterData[14]));
+
+		await clickNthElement(scatterItems, 15);
+		expect(onClick).toHaveBeenCalledWith(expect.objectContaining(characterData[15]));
 	});
 
 	describe('Popover', () => {

--- a/src/types/Chart.ts
+++ b/src/types/Chart.ts
@@ -182,6 +182,8 @@ export interface DonutProps extends MarkProps {
 	/** Determines if the center metric should be displayed as a percent. if true, data should only be two data points, which sum to 1
 	 * Also, if true, will display the first datapoint as a percent */
 	isBoolean?: boolean;
+	/** callback that will be run when a donut item is selected */
+	onClick?: (datum: Datum) => void;
 }
 
 export interface DonutSummaryProps {
@@ -436,6 +438,8 @@ export interface ScatterProps extends Omit<MarkProps, 'color'> {
 	 * point fill and stroke opacity
 	 * uses a key in the data that will map to the opacity scale or a opacity value
 	 */
+	/** callback that will be run when a scatter item is selected */
+	onClick?: (datum: Datum) => void;
 	opacity?: OpacityFacet;
 	/**
 	 * point size

--- a/src/utils/utils.ts
+++ b/src/utils/utils.ts
@@ -218,7 +218,7 @@ export function getElement(
  */
 export const getAllMarkElements = (
 	target: unknown,
-	source: MarkElement[],
+	sources: MarkElement[],
 	elements: MappedElement[] = [],
 	name: string = ''
 ): MappedElement[] => {
@@ -233,7 +233,7 @@ export const getAllMarkElements = (
 		return elements;
 	}
 	// if the type matches, we found our element
-	if (target.type === source) {
+	if ((sources.some (source => target.type === source))) {
 		return [...elements, { name, element: target as ChartElement | RscElement }];
 	}
 
@@ -245,7 +245,7 @@ export const getAllMarkElements = (
 	const desiredElements: MappedElement[] = [];
 	for (const child of toArray(target.props.children)) {
 		const childName = getElementName(child, elementCounts);
-		desiredElements.push(...getAllMarkElements(child, source, elements, [name, childName].filter(Boolean).join('')));
+		desiredElements.push(...getAllMarkElements(child, sources, elements, [name, childName].filter(Boolean).join('')));
 	}
 	// no element matches found, give up all hope...
 	return [...elements, ...desiredElements];

--- a/src/utils/utils.ts
+++ b/src/utils/utils.ts
@@ -55,6 +55,7 @@ import {
 	TrendlineElement,
 } from '../types';
 
+type MarkElement = typeof Bar | typeof Donut | typeof Scatter;
 type MappedElement = { name: string; element: ChartElement | RscElement };
 type ElementCounts = {
 	area: number;
@@ -217,12 +218,7 @@ export function getElement(
  */
 export const getAllMarkElements = (
 	target: unknown,
-	source:
-		| typeof Area
-		| typeof Bar
-		| typeof Donut
-		| typeof Line
-		| typeof Scatter,
+	source: MarkElement[],
 	elements: MappedElement[] = [],
 	name: string = ''
 ): MappedElement[] => {


### PR DESCRIPTION
onClick prop is now enabled for Donut and Scatter marks.

- More than one type is allowed for searching for all mark elements
- OnClick stories created
- All existing test cases, as well as additional tests for Donut and Scatter onClick pass

https://github.com/user-attachments/assets/12273885-87cf-4a5a-886f-9fbe48f9e15c



